### PR TITLE
Fix 404s in dev and "Module not found" in production for TS files containing only types

### DIFF
--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -746,7 +746,7 @@ export async function startServer(
       throw err;
     }
 
-    if (finalizedResponse) {
+    if (finalizedResponse !== undefined) {
       return {
         imports: resolvedImports,
         contents: encodeResponse(finalizedResponse, encoding),


### PR DESCRIPTION
- Fixes https://github.com/withastro/snowpack/issues/3285
- Fixes https://github.com/withastro/snowpack/issues/3585

When building a TS file with only types, esbuild strips out all of the type info and returns an *empty string* as the result of the compilation (`''`). `loadUrl()` just does a **falsy check** on the return value from `fileBuilder.getResult`, which can be any of `string | Buffer | undefined`. When the empty string is returned, the falsy check doesn't pass, so the load appears to be unsuccessful even though the empty string indicates successful output. Changing the falsy check to an explicit check for `undefined` allows the empty string to be treated as a successful response.

An alternative to this approach might be to just ignore the import entirely (somehow) if the response is empty. That would potentially save a bunch of useless requests from being sent. But this is at least a step in the right direction that helps code like this to be runnable at least.

## Changes

- .ts files that contain only types result in the empty string (`''`) when being compiled by esbuild
- Currently, snowpack believes such a result is unsuccessful, and so trying to import those files results in 404s
- Now, the empty files are treated as successful and returned as-is, so there are no more 404s for files containing only types

## Testing

- I ran the dev server/build locally with and without this change
- Without the change, the dev server gives me 404s on all files that contain only type information, and the `build` command fails with a slew of "Module not found" errors
- With this change, the dev server operates correctly, my app works, and the `build` command succeeds
- [This bug](https://github.com/withastro/snowpack/issues/3585) contains a reproducible example, I believe

## Docs

- No -- this is only a bug fix