### PR TITLE
Update configuration.md, update documentation for `mount`

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -73,10 +73,11 @@ mount: {
 
 Mount local directories to custom URLs in your built application.
 
-- `mount.url` | `string` | _required_ : The URL to mount to, matching the string in the simple form above.
-- `mount.static` | `boolean` | _optional_ | **Default**: `false` : If true, don't build files in this directory. Copy and serve them directly from disk to the browser.
-- `mount.resolve` | `boolean` | _optional_ | **Default**: `true`: If false, don't resolve JS & CSS imports in your JS, CSS, and HTML files. Instead send every import to the browser, as written.
-- `mount.dot` | `boolean` | _optional_ | **Default**: `false`: If true, include dotfiles (ex: `.htaccess`) in the final build.
+- `mount.path` | `string` | _required_ : The relative directory path to mount from `src: '/dist'` is equivalent to `'./src': '/dist'`
+- `mount.path.url` | `string` | _required_ : The URL to mount to, matching the string in the simple form above.
+- `mount.path.static` | `boolean` | _optional_ | **Default**: `false` : If true, don't build files in this directory. Copy and serve them directly from disk to the browser.
+- `mount.path.resolve` | `boolean` | _optional_ | **Default**: `true`: If false, don't resolve JS & CSS imports in your JS, CSS, and HTML files. Instead send every import to the browser, as written.
+- `mount.path.dot` | `boolean` | _optional_ | **Default**: `false`: If true, include dotfiles (ex: `.htaccess`) in the final build.
 
 Example:
 
@@ -107,6 +108,20 @@ export default {
   },
 };
 ```
+
+Example of `mount`, where the `index.js` is in `./my-todo-app/frontend`:
+
+```js
+// snowpack.config.mjs
+// Example: Alternate "mount" from "path"
+export default {
+  mount: {
+    './my-todo-app/frontend': '/dist',
+    public: '/',
+  },
+};
+```
+
 
 ## env
 


### PR DESCRIPTION

## Changes

Adding some extra words about `[path: string]: string | {url....` where `path` means the relative directory path.

![2022-01-03_18-48](https://user-images.githubusercontent.com/33908344/147995482-5c80fba3-f76e-4ae3-8b7c-d5a432945e21.png)
![2022-01-03_18-49](https://user-images.githubusercontent.com/33908344/147995489-3a7b40a3-e7a4-4ff9-93b6-426a1f1fac8a.png)

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->

```
06:56:38 jm@jm snowpack ±|main ✗|→ yarn test:docs
yarn run v1.22.11
$ cd www && yarn && yarn test --passWithNoTests
[1/4] Resolving packages...
success Already up-to-date.
error Command "test" not found.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
06:56:42 jm@jm snowpack ±|main ✗|→ 

```
## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->

Yes
