### PR TITLE
Make Vue compiler in `@snowpack/plugin-vue` configurable

### DIFF
--- a/plugins/plugin-vue/README.md
+++ b/plugins/plugin-vue/README.md
@@ -22,7 +22,8 @@ export default {
 
 You may customize Vue's bundler behavior using the following plugin options.
 
-| Name           |   Type    | Description                                                                                          |
-| :------------- | :-------: | :--------------------------------------------------------------------------------------------------- |
-| `optionsApi`   | `boolean` | Enable/disable [Options API](https://v3.vuejs.org/api/options-api.html) support. Defaults to `true`. |
-| `prodDevtools` | `boolean` | Enable/disable devtools support in production. Defaults to `false`.                                  |
+| Name              |   Type    | Description                                                                                          |
+| :---------------- | :-------: | :--------------------------------------------------------------------------------------------------- |
+| `optionsApi`      | `boolean` | Enable/disable [Options API](https://v3.vuejs.org/api/options-api.html) support. Defaults to `true`. |
+| `prodDevtools`    | `boolean` | Enable/disable devtools support in production. Defaults to `false`.                                  |
+| `compilerOptions` | `object`  | Pass additional configuration to the vue template compiler. Defaults to `{}`                         |

--- a/plugins/plugin-vue/plugin.js
+++ b/plugins/plugin-vue/plugin.js
@@ -140,6 +140,7 @@ module.exports = function plugin(snowpackConfig, pluginOptions = {}) {
           preprocessLang: descriptor.template.lang,
           compilerOptions: {
             scopeId: scoped ? `data-v-${id}` : null,
+            ...pluginOptions.compilerOptions,
           },
         });
         if (js.errors && js.errors.length > 0) {


### PR DESCRIPTION
## Changes

This PR adds the possibility to configure the vue compiler in `@snowpack/plugin-vue`. 

**Before:**
```js
// snowpack.config.mjs
export default {
  plugins: [
    ['@snowpack/plugin-vue', { /* No possibility to pass configuration options to the vue compiler */ }]
  ]
}
```

**After:**
```js
// snowpack.config.mjs
export default {
  plugins: [
    ['@snowpack/plugin-vue', { compilerOptions: { isCustomElement: (tag) => tag.startsWith('lit-') } }]
  ]
}
```

## Testing

This change was tested locally in my existing setup. It worked, and should not be breaking anything else, since it's just one line of code added, without side effects.

## Docs

`plugins/plugin-vue/README.md` was updated accordingly.
