### PR TITLE
Update hmr.ts

### DIFF
--- a/snowpack/src/dev/hmr.ts
+++ b/snowpack/src/dev/hmr.ts
@@ -15,7 +15,7 @@ export function startHmrEngine(
 ) {
   const {hmrDelay} = config.devOptions;
   const hmrPort = config.devOptions.hmrPort || serverPort;
-  const hmrEngine = new EsmHmrEngine({server, port: hmrPort, delay: hmrDelay});
+  const hmrEngine = new EsmHmrEngine({server: (hmrPort == serverPort ? server : null) , port: hmrPort, delay: hmrDelay});
   onProcessExit(() => {
     hmrEngine.disconnectAllClients();
   });


### PR DESCRIPTION
This is to fix the bug that if the hmrPort != port, a server is not started on the hmrPort and HMR doesn't work

## Changes

If the server is supplied it is not checking to see whether the hmrPort is different to the server port. If it is different, a new server needs to be started on the HMR port. Supplying null to her-server-enngine will cause it to start a new server on that port

## Testing

tested locally with hmrPort!=port, works correctly

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
