### PR TITLE
Fix sass compiler-option loadPath

### DIFF
--- a/plugins/plugin-sass/plugin.js
+++ b/plugins/plugin-sass/plugin.js
@@ -175,7 +175,7 @@ module.exports = function sassPlugin(snowpackConfig, {native, compilerOptions = 
           }
           case 'string':
           case 'number': {
-            if (flagName === 'loadPath') {
+            if (flagName === 'load-path') {
               loadPaths.add(value); // don’t add these until default load paths are collected
             } else {
               args.push(`--${flagName}=${value}`);


### PR DESCRIPTION
## Changes

A quick fix to a the broken `loadPath` option of plugin-sass.

## Testing

Manually tested, because I consider this is a very minor change and my setup doesn't like the test-suite.

## Docs

bug fix only
