### PR TITLE
fixed typo

### DIFF
--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -72,7 +72,7 @@ Add the Snowpack development server to `package.json` under as the `start` scrip
 ```diff
   "scripts": {
 +   "start": "snowpack dev",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo 'Error: no test specified' && exit 1"
   },
 
 ```


### PR DESCRIPTION
This line
`"test": "echo \"Error: no test specified\" && exit 1"`
had nested double quotes that caused an error.

## Changes

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->
`"test": "echo \"Error: no test specified\" && exit 1"`
had nested double quotes that caused an error.

I changed it to 
`"test": "echo 'Error: no test specified' && exit 1"`

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why -->
I tested the corrected line in my own development environment.

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
This itself was a change to documentation.

Also, I realize this may not be the right place to mention it, but I would recommend removing the `+` in this section as well since when you copy and paste the plus comes with it.
